### PR TITLE
Add ipdb to anaconda generic config

### DIFF
--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -202,6 +202,7 @@ collections:
       - importlib_metadata
       - incremental
       - intel-openmp
+      - ipdb
       - ipykernel
       - ipyparallel
       - ipython


### PR DESCRIPTION
- ipdb is a useful thing to have, I have been recommending it to several people.  This recommendation is more difficult since it's not there by default.