### PR TITLE
anaconda: Add two packages useful for tracking dependencies

### DIFF
--- a/configs/fgci-centos7-dev/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-dev/anaconda/build_config.yaml
@@ -97,6 +97,7 @@ collections:
       - colorama
       - conda
       - conda-env
+      - conda-tree
       - contextlib2
       - coverage
       - cplex
@@ -164,6 +165,7 @@ collections:
       - phonopy
       - pillow
       - pip
+      - pipdeptree
       - pixman
       - plotly
       - ply


### PR DESCRIPTION
- pipdeptree: show the minimum set of dependencies needed to pull in
  all other Python dependencies.
- conda-tree: similar but for all conda packages.
- Both were very useful for filtering down the installed packages to
  the actually useful set.