### PR TITLE
anaconda: remove cdlib

### DIFF
--- a/configs/fgci-centos7-dev/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-dev/anaconda/build_config.yaml
@@ -63,7 +63,6 @@ collections:
   triton-generic:
     pip_packages:
       - bash-kernel
-      - cdlib
       - docopt
       - matlab-kernel
       - mne


### PR DESCRIPTION
- I added cdlib upon request, but immediately regretted it because it
  caused a lot of packages to be downgraded.  This was because their
  requirements file was too strict, pinning exact dependencies instead
  of >=.  I made an issue and they relaxed it some.
- But it's still not enough as of this writing:
  https://github.com/GiulioRossetti/cdlib/blob/master/requirements.txt
- e.g. it pins Sphinx to 1.7.5 exactly along with a few other things
  (and a less than or equal to, too.).  This is a good idea for a
  workflow, but not for a library packages that may be expected to be
  installed along any other arbitrary packages.
- So, I think this has to be removed and installed in virtualenvs
  only.  We can try again later.
- ref: https://github.com/GiulioRossetti/cdlib/issues/79