### PR TITLE
fgci-centos7-generic: Adding opencv-contrib-python

### DIFF
--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -103,6 +103,7 @@ collections:
       - jupyterlab-git
       - matlab-kernel
       - nbzip
+      - opencv-contrib-python
       - pymanopt
       - python-igraph
       - roboschool


### PR DESCRIPTION
This PR adds pre-built opencv packages from [opencv-contrib-python](https://pypi.org/project/opencv-contrib-python/). Conda's opencv-package was not working as that brought it with some dependency resolution problems.