### PR TITLE
fgci-centos7-generic: Adding feather-format to generic build

### DIFF
--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -147,6 +147,7 @@ collections:
       - docutils
       - fastcache
       - fastparquet
+      - feather-format
       - gmpy2
       - gpy
       - gurobi


### PR DESCRIPTION
This PR adds [feather's](https://github.com/wesm/feather) conda-forge provided Python implementation [feather-format](https://anaconda.org/conda-forge/feather-format).

This package is great package for users that use CSV's or other non-binary formats for their data handling.