### PR TITLE
buildrules/ci.py: Adding option for setting configs repository

### DIFF
--- a/buildrules/ci.py
+++ b/buildrules/ci.py
@@ -23,6 +23,7 @@ class CIBuilder(Builder):
         'patternProperties': {
             'build_environment_repository': {'type': 'string'},
             'science_build_rules_repository': {'type': 'string'},
+            'science_build_configs_repository': {'type': 'string'},
             'build_folder': {'type': 'string'},
             'compose_project_name': {'type': 'string'},
             'buildbot_master': {


### PR DESCRIPTION
This adds a new setting for the ci-builder for setting a configs repository that the builder should follow.