### PR TITLE
Build config/fqdn for ci-builder

### DIFF
--- a/buildrules/ci.py
+++ b/buildrules/ci.py
@@ -26,11 +26,11 @@ class CIBuilder(Builder):
             'science_build_configs_repository': {'type': 'string'},
             'build_folder': {'type': 'string'},
             'compose_project_name': {'type': 'string'},
+            'fqdn': {'type': 'string'},
             'buildbot_master': {
                 'type': 'object',
                 'properties': {
                     'image': {'type': 'string'},
-                    'fqdn': {'type': 'string'},
                     'private_key': {'type': 'string'},
                     'public_cert':  {'type': 'string'},
                     'web_port': {'type': 'integer'},
@@ -44,7 +44,6 @@ class CIBuilder(Builder):
                 },
                 'required': [
                     'image',
-                    'fqdn',
                     'worker_password',
                     'worker_uid'
                 ],
@@ -210,6 +209,7 @@ class CIBuilder(Builder):
             'build_folder',
             'buildbot_master',
             'buildbot_db',
+            'fqdn',
         ],
     }]
 
@@ -417,7 +417,7 @@ class CIBuilder(Builder):
 
     def _copy_certs(self):
 
-        fqdn = self._confreader['build_config']['buildbot_master']['fqdn']
+        fqdn = self._confreader['build_config']['fqdn']
         private_key = self._confreader['build_config']['buildbot_master'].get('private_key', None)
         public_cert = self._confreader['build_config']['buildbot_master'].get('public_cert', None)
         key = os.path.join(self._build_folder, 'certs', 'buildbot.key')

--- a/buildrules/ci/templates/buildbot_master.cfg.j2
+++ b/buildrules/ci/templates/buildbot_master.cfg.j2
@@ -110,7 +110,7 @@ def portusParameters(props):
 c['title'] = "CI builds"
 c['titleURL'] = ""
 
-c['buildbotURL'] = "https://{{ buildbot_master.fqdn | default("localhost") }}/"
+c['buildbotURL'] = "https://{{ fqdn }}/"
 
 c['protocols'] = {'pb': {'port': {{ buildbot_master.worker_port | default(9989) }} } }
 

--- a/buildrules/ci/templates/nginx.conf.j2
+++ b/buildrules/ci/templates/nginx.conf.j2
@@ -40,7 +40,7 @@ http {
 
   server {
     listen 443 ssl http2;
-    server_name {{ buildbot_master.fqdn }};
+    server_name {{ fqdn }};
     root html;
 
     ##


### PR DESCRIPTION
Changes in this PR: The option to specify fully qualified domain name is moved higher in the configuration hierarchy (from buildbot_master.fqdn to fqdn) in build_config.yaml for ci-builder.